### PR TITLE
#71 random range and census change

### DIFF
--- a/src/components/main/RandomHPPDInfo.js
+++ b/src/components/main/RandomHPPDInfo.js
@@ -13,9 +13,9 @@ class RandomHPPDInfo extends React.Component {
     setRandomValues = () =>
       {
 
-        let randomHPPD = this.random(8,24);
-        let randomCensus = this.random(1,100);
-        let randomBedUnit = this.random(10,1000);
+        let randomHPPD = this.random(1,30);
+        let randomBedUnit = this.random(1,60);
+        let randomCensus = this.random(1,randomBedUnit);
 
         let info ={
             unit:"Random Hospital Unit",

--- a/src/components/main/Scenario.js
+++ b/src/components/main/Scenario.js
@@ -47,7 +47,7 @@ class Scenario extends React.Component {
         //Maybe look at using Formik library?
         //https://react-bootstrap.github.io/components/forms/#forms-validation-native
         //https://react-bootstrap.github.io/components/forms/#forms-validation-libraries
-
+        // TODO: will have to add in check to make sure that census doesn't exceed bedUnit
         const target = event.target;
         const value = target.type === 'checkbox' ? target.checked : target.value;
         const name = target.name;
@@ -62,7 +62,10 @@ class Scenario extends React.Component {
         //https://stackoverflow.com/questions/43638938/updating-an-object-with-setstate-in-react
         this.setState(prevState => {
             let info = Object.assign({}, prevState.info);   // creating copy of state variable info
-            info[name] = value;                             // update the name property, assign a new value                 
+            info[name] = value;                             // update the name property, assign a new value 
+            if (name === 'bedUnit') {                       // if bedUnit, census should default to same value
+                info['census'] = value;
+            }              
             return { info };                                // return new object info object
         })
 


### PR DESCRIPTION
The ranges for the random value generation has been updated to the values we discussed with the sponsor: 
HPPD: 1-30
number of beds: 1-60
census: 1-number of beds
Also, the census defaults to whatever the value is entered for number of beds in the scenario if the user manually changes that. 

My error handling task will keep the census from being changed to a number higher than the number of beds, so that isn't taken care of in this task.