### PR TITLE
#78 staff budget

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -28,12 +28,6 @@ test('Scenario content renders', () => {
   expect(HeaderElement).toBeInTheDocument();
 });
 
-
-//Will need to be uncommented when merge happens
-// test('Staff content renders', () => {
-//   render(<AppInMain />);
-// });
-
 // testing reload image click in header
 // found implementation that I built on top of here: https://stackoverflow.com/a/61649798
 test('reload on image click works', () => {

--- a/src/RandomHPPDInfo.test.js
+++ b/src/RandomHPPDInfo.test.js
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Scenario from './components/main/Scenario.js';
+
+// Random button test
+describe("<RandomHPPDInfo />", () => {
+    test('Test random button', () => {
+        render(<Scenario />);
+
+        const inputUnit = screen.getByTestId("unit-id");
+        const inputHppd = screen.getByTestId("hppd-id");
+        const inputCensus = screen.getByTestId("census-id");
+        const inputNumbeds = screen.getByTestId("numbeds-id");
+        const randomBtn = screen.getByTestId("random-id");
+
+        // initial checking of component elements
+        expect(inputUnit).toBeInTheDocument();
+        expect(inputUnit).toHaveAttribute("type", "text");
+        expect(inputHppd).toBeInTheDocument();
+        expect(inputHppd).toHaveAttribute("type", "number");
+        expect(inputCensus).toBeInTheDocument();
+        expect(inputCensus).toHaveAttribute("type", "number");
+        expect(inputNumbeds).toBeInTheDocument();
+        expect(inputNumbeds).toHaveAttribute("type", "number");
+        expect(randomBtn).toBeInTheDocument();
+        expect(randomBtn).toHaveAttribute("type", "button");
+
+        // before random is clicked, everything should be null/undefined
+        expect(screen.getByTestId("hppd-id")).toHaveValue(null);
+        expect(screen.getByTestId("unit-id")).toHaveValue("");
+        expect(screen.getByTestId("census-id")).toHaveValue(null);
+        expect(screen.getByTestId("numbeds-id")).toHaveValue(null);
+
+        // click random button
+        userEvent.click(randomBtn);
+
+        // after button is clicked, expect values to change
+        // have to parse number values back out since HTML value field is string
+        const newHPPD = screen.getByTestId("hppd-id");
+        let hppdnum = parseInt(newHPPD.value, 10);
+        expect(hppdnum).toBeGreaterThan(0);
+        expect(hppdnum).toBeLessThan(31);
+        expect(screen.getByTestId("unit-id")).toHaveValue("Random Hospital Unit");
+        const newNumbeds = screen.getByTestId("numbeds-id");
+        let numbedsnum = parseInt(newNumbeds.value, 10);
+        expect(numbedsnum).toBeGreaterThan(0);
+        expect(numbedsnum).toBeLessThan(61);
+        const newCensus = screen.getByTestId("census-id");
+        let censusNum = parseInt(newCensus.value, 10);
+        expect(censusNum).toBeGreaterThan(0);
+        expect(censusNum).toBeLessThanOrEqual(numbedsnum);
+    });
+})

--- a/src/StaffAdd.test.js
+++ b/src/StaffAdd.test.js
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import StaffAdd from './components/main/StaffAdd';
+import Scenario from './components/main/Scenario';
+
+// Staff Add button test
+describe("<StaffAdd />", () => {
+    test('Test add staff to open modal button', () => {
+        render(<StaffAdd/>);
+
+        const staffAddBtn = screen.getByTestId("addstaff-id");
+
+        // expected initial values
+        expect(staffAddBtn).toBeInTheDocument();
+
+        // button click
+        userEvent.click(staffAddBtn);
+
+        // after staffAdd clicked, modal should be visible
+        const staffAddModal = screen.getByTestId("addStaffModal-id");
+        expect(staffAddModal).toBeInTheDocument();
+        expect(staffAddModal).toBeVisible();
+    });
+
+    test('Test confirm add new staff button', () => {
+        render(<Scenario/>);
+
+        const staffAddBtn = screen.getByTestId("addstaff-id");
+
+        // expected initial values
+        expect(staffAddBtn).toBeInTheDocument();
+
+        // button click to get modal up
+        userEvent.click(staffAddBtn);
+
+        // make sure modal and "Add New Staff" button are there
+        const staffAddModal = screen.getByTestId("addStaffModal-id");
+        expect(staffAddModal).toBeInTheDocument();
+        const confirmStaffAddBtn = screen.getByTestId("addStaffConfirm-id");
+        expect(confirmStaffAddBtn).toBeInTheDocument();
+
+        // add default staff choices
+        userEvent.click(confirmStaffAddBtn);
+        expect(staffAddModal).not.toBeInTheDocument(); // modal disappears on add
+
+        // make sure staff member was added
+        const staffListTable = screen.getByTestId("staffList-id");
+        expect(staffListTable).toBeInTheDocument();
+        const newStaff = screen.getByText("RN");
+        expect(newStaff).toBeInTheDocument();
+    });
+
+    test('Test cancel add staff button', () => {
+        render(<Scenario/>);
+
+        const staffAddBtn = screen.getByTestId("addstaff-id");
+
+        // expected initial values
+        expect(staffAddBtn).toBeInTheDocument();
+
+        // button click to get modal up
+        userEvent.click(staffAddBtn);
+
+        // make sure modal and cancel button are there
+        const staffAddModal = screen.getByTestId("addStaffModal-id");
+        expect(staffAddModal).toBeInTheDocument();
+        const cancelBtn = screen.getByTestId("cancelStaffAdd-id");
+        expect(cancelBtn).toBeInTheDocument();
+
+        // cancel staff add
+        userEvent.click(cancelBtn);
+        
+        // make sure modal is gone and staff member wasn't added
+        expect(staffAddModal).not.toBeInTheDocument();
+        expect(screen.queryByText("Staff Type")).toBeNull();
+    });
+})

--- a/src/StaffBudget.test.js
+++ b/src/StaffBudget.test.js
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Scenario from './components/main/Scenario.js';
+import StaffAdd from './components/main/StaffAdd.js';
+
+//     test('Test confirm add new staff button', () => {
+//     render(<Scenario/>);
+
+//     const staffAddBtn = screen.getByTestId("addstaff-id");
+
+//     // expected initial values
+//     expect(staffAddBtn).toBeInTheDocument();
+
+//     // button click to get modal up
+//     userEvent.click(staffAddBtn);
+
+//     // make sure modal and "Add New Staff" button are there
+//     const staffAddModal = screen.getByTestId("addStaffModal-id");
+//     expect(staffAddModal).toBeInTheDocument();
+//     const confirmStaffAddBtn = screen.getByTestId("addStaffConfirm-id");
+//     expect(confirmStaffAddBtn).toBeInTheDocument();
+
+//     // add default staff choices
+//     userEvent.click(confirmStaffAddBtn);
+//     expect(staffAddModal).not.toBeInTheDocument(); // modal disappears on add
+
+//     // make sure staff member was added
+//     const staffListTable = screen.getByTestId("staffList-id");
+//     expect(staffListTable).toBeInTheDocument();
+//     const newStaff = screen.getByText("RN");
+//     expect(newStaff).toBeInTheDocument();
+// });
+
+// Test budget
+describe("<StaffBudget />", () => {
+    test('Test show budget', () => {
+        render(<Scenario />);
+        const showBudget = screen.getByTestId("showbudget-id");
+
+        // initial expected value - budget shouldn't be on page
+        expect(screen.queryByText("Total Budget for Staff")).toBeNull();
+
+        // show budget checked
+        userEvent.click(showBudget);
+        expect(showBudget).toBeChecked();
+        expect(screen.getByText("Total Budget for Staff")).toBeInTheDocument();
+    });
+
+    test('Test budget accuracy', () => {
+        render(<Scenario/>);
+        const showBudget = screen.getByTestId("showbudget-id");
+
+        // initial budget should be 0
+        userEvent.click(showBudget);
+        expect(showBudget).toBeChecked();
+        expect(screen.getByText("$0")).toBeInTheDocument();
+
+        // add staff
+        const staffAddBtn = screen.getByTestId("addstaff-id");
+        userEvent.click(staffAddBtn);
+        const confirmStaffAddBtn = screen.getByTestId("addStaffConfirm-id");
+        userEvent.click(confirmStaffAddBtn);
+
+        // check budget value
+        expect(screen.getByText("$420")).toBeInTheDocument();
+    });
+})

--- a/src/StaffList.test.js
+++ b/src/StaffList.test.js
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import StaffAdd from './components/main/StaffAdd';
+import Scenario from './components/main/Scenario';
+
+// Test buttons for StaffList
+describe("<StaffList/>", () => {
+    test('Test delete staff button', () => {
+        render(<Scenario />);
+
+        const staffAddBtn = screen.getByTestId("addstaff-id");
+
+        // expected initial values
+        expect(staffAddBtn).toBeInTheDocument();
+
+        // button click to get modal up
+        userEvent.click(staffAddBtn);
+
+        // make sure modal and "Add New Staff" button are there
+        const staffAddModal = screen.getByTestId("addStaffModal-id");
+        expect(staffAddModal).toBeInTheDocument();
+        const confirmStaffAddBtn = screen.getByTestId("addStaffConfirm-id");
+        expect(confirmStaffAddBtn).toBeInTheDocument();
+
+        // add default staff choices
+        userEvent.click(confirmStaffAddBtn);
+        expect(staffAddModal).not.toBeInTheDocument(); // modal disappears on add
+
+        // make sure staff member was added
+        const staffListTable = screen.getByTestId("staffList-id");
+        expect(staffListTable).toBeInTheDocument();
+        const newStaff = screen.getByText("RN");
+        expect(newStaff).toBeInTheDocument();
+
+        // delete staff
+        const deleteBtn = screen.getByTestId("delete-id");
+        expect(deleteBtn).toBeInTheDocument();
+        userEvent.click(deleteBtn);
+        expect(newStaff).not.toBeInTheDocument();
+    });
+
+    test('Test add and minus buttons', () => {
+        render(<Scenario />);
+
+        const staffAddBtn = screen.getByTestId("addstaff-id");
+
+        // expected initial values
+        expect(staffAddBtn).toBeInTheDocument();
+
+        // button click to get modal up
+        userEvent.click(staffAddBtn);
+
+        // make sure modal and "Add New Staff" button are there
+        const staffAddModal = screen.getByTestId("addStaffModal-id");
+        expect(staffAddModal).toBeInTheDocument();
+        const confirmStaffAddBtn = screen.getByTestId("addStaffConfirm-id");
+        expect(confirmStaffAddBtn).toBeInTheDocument();
+
+        // add default staff choices
+        userEvent.click(confirmStaffAddBtn);
+        expect(staffAddModal).not.toBeInTheDocument(); // modal disappears on add
+
+        // make sure staff member was added
+        const staffListTable = screen.getByTestId("staffList-id");
+        expect(staffListTable).toBeInTheDocument();
+        const newStaff = screen.getByText("RN");
+        expect(newStaff).toBeInTheDocument();
+        let staffQty = screen.getByText("1");
+        expect(staffQty).toBeInTheDocument();
+
+        // add staff quantity
+        const addBtn = screen.getByTestId("add-id");
+        expect(addBtn).toBeInTheDocument();
+        userEvent.click(addBtn);
+        staffQty = screen.getByText("2");
+        expect(staffQty).toBeInTheDocument();
+
+        // subtract staff quantity
+        const subtractBtn = screen.getByTestId("minus-id");
+        expect(subtractBtn).toBeInTheDocument();
+        userEvent.click(subtractBtn);
+        staffQty = screen.getByText("1");
+        expect(staffQty).toBeInTheDocument();
+    });
+})

--- a/src/components/main/RandomHPPDInfo.js
+++ b/src/components/main/RandomHPPDInfo.js
@@ -33,7 +33,7 @@ class RandomHPPDInfo extends React.Component {
 
 
         return (
-            <button type="button" className="btn btn-outline-primary" onClick={this.setRandomValues}>Random Scenario</button>
+            <button type="button" className="btn btn-outline-primary" data-testid="random-id" onClick={this.setRandomValues}>Random Scenario</button>
         );
     }
 }

--- a/src/components/main/Scenario.js
+++ b/src/components/main/Scenario.js
@@ -5,6 +5,7 @@ import StaffAdd from './StaffAdd'
 import StaffList from './StaffList'
 import Result from './Result'
 import RandomHPPDInfo from './RandomHPPDInfo'
+import StaffBudget from './StaffBudget';
 
 class Scenario extends React.Component {
     constructor(props) {
@@ -15,6 +16,7 @@ class Scenario extends React.Component {
             num: "",
             center: { "text-align": 'center' },
             staffs: [],
+            showBudget: false,
             info: {
                 unit: "",
                 HPPD: "",
@@ -75,16 +77,28 @@ class Scenario extends React.Component {
             if (name === 'bedUnit') {                       // if bedUnit, census should default to same value
                 info['census'] = value;
             }
-            
+
             // clear error if it's been resolved
             let errors = Object.assign({}, prevState.errors);
-            if ( !!errors[name] && errors[name] !== newErrors[name]) {
+            if (!!errors[name] && errors[name] !== newErrors[name]) {
                 errors[name] = null;
             }
 
             return { info, errors };                                // return new info and error objects
         })
 
+    }
+
+    // handle show budget check change
+    handleCheckChange = (event) => {
+        const target = event.target;
+        const value = target.checked;
+
+        this.setState(prevState => {
+            let showBudget = Object.assign({}, prevState.showBudget);
+            showBudget = value;
+            return { showBudget };
+        })
     }
 
     // https://dev.to/alecgrey/controlled-forms-with-front-and-backend-validations-using-react-bootstrap-5a2
@@ -115,10 +129,11 @@ class Scenario extends React.Component {
 
                 <div className="row mt-5">
 
-                     <div className="col-md-3 col-sm-6 order-sm-last">
+                    <div className="col-md-3 col-sm-6 order-sm-last">
                         <Result staffs={this.state.staffs} info={this.state.info} ></Result>
+                        <StaffBudget staffs={this.state.staffs} showBudget={this.state.showBudget}></StaffBudget>
                     </div>
-                    
+
                     {/* Form has to be used instead of form because of validation feedback and bootstrap version used */}
                     <div className="col-md-9 col-sm-6 order-sm-first">
                         <Form className="row" noValidate>
@@ -130,20 +145,20 @@ class Scenario extends React.Component {
 
                             <div className="col-md-4">
                                 <Form.Label htmlFor="HPPD" >HPPD</Form.Label>
-                                <Form.Control type="number" name="HPPD" id="HPPD" data-testid="hppd-id" placeholder="HPPD" onChange={this.handleInputChange} value={this.state.info.HPPD} isInvalid={ !!this.state.errors.HPPD }/>
-                                <Form.Control.Feedback type="invalid" >{ this.state.errors.HPPD }</Form.Control.Feedback>
+                                <Form.Control type="number" name="HPPD" id="HPPD" data-testid="hppd-id" placeholder="HPPD" onChange={this.handleInputChange} value={this.state.info.HPPD} isInvalid={!!this.state.errors.HPPD} />
+                                <Form.Control.Feedback type="invalid" >{this.state.errors.HPPD}</Form.Control.Feedback>
                             </div>
 
                             <div className="col-md-4">
                                 <Form.Label htmlFor="bedUnit">Number of beds</Form.Label>
-                                <Form.Control type="number" name="bedUnit" id="bedUnit" data-testid="numbeds-id" placeholder="Number of Beds" onChange={this.handleInputChange} value={this.state.info.bedUnit} isInvalid={ !!this.state.errors.bedUnit }/>
-                                <Form.Control.Feedback type="invalid" >{ this.state.errors.bedUnit }</Form.Control.Feedback>
+                                <Form.Control type="number" name="bedUnit" id="bedUnit" data-testid="numbeds-id" placeholder="Number of Beds" onChange={this.handleInputChange} value={this.state.info.bedUnit} isInvalid={!!this.state.errors.bedUnit} />
+                                <Form.Control.Feedback type="invalid" >{this.state.errors.bedUnit}</Form.Control.Feedback>
                             </div>
 
                             <div className="col-md-4">
                                 <Form.Label htmlFor="census">Census</Form.Label>
-                                <Form.Control type="number" name="census" id="census" data-testid="census-id" placeholder="Census" onChange={this.handleInputChange} value={this.state.info.census} isInvalid={ !!this.state.errors.census }/>
-                                <Form.Control.Feedback type="invalid" >{ this.state.errors.census }</Form.Control.Feedback>
+                                <Form.Control type="number" name="census" id="census" data-testid="census-id" placeholder="Census" onChange={this.handleInputChange} value={this.state.info.census} isInvalid={!!this.state.errors.census} />
+                                <Form.Control.Feedback type="invalid" >{this.state.errors.census}</Form.Control.Feedback>
                             </div>
 
                         </Form>
@@ -154,16 +169,24 @@ class Scenario extends React.Component {
                             <div className="col-md-4 mt-4 ">
                                 <RandomHPPDInfo onInfoChange={this.handleInfoChange} />
                             </div>
+                            <div className="col-md-4 mt-4">
+                                <Form.Check 
+                                    type="checkbox"
+                                    id="showBudget"
+                                    label="Show Budget"
+                                    name="showBudget"
+                                    data-testid="showbudget-id"
+                                    checked={this.state.showBudget}
+                                    onChange={this.handleCheckChange}
+                                />
+                            </div>
                         </div>
 
-                    </div>
-                    
-                    
-
-                </div>
-                <div className="row mt-5">
-                    <div className="col-md-9">
-                        <StaffList staffs={this.state.staffs} onStaffChangeOnUpdate={this.handleStaffChange} ></StaffList>
+                        <div className="row mt-5">
+                            {/* <div className="col-md-9"> */}
+                                <StaffList staffs={this.state.staffs} onStaffChangeOnUpdate={this.handleStaffChange} ></StaffList>
+                            {/* </div> */}
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/components/main/StaffAdd.js
+++ b/src/components/main/StaffAdd.js
@@ -85,9 +85,9 @@ class StaffAdd extends React.Component {
 
 		return (
             <div>  
-			<button type="button" className="btn btn-outline-primary" onClick={this.handleShow}>Add Staff</button>
+			<button type="button" className="btn btn-outline-primary" data-testid="addstaff-id" onClick={this.handleShow}>Add Staff</button>
 				
-				<Modal animation={false} show={this.state.show} onHide={this.handleClose}>
+				<Modal animation={false} show={this.state.show} data-testid="addStaffModal-id" onHide={this.handleClose}>
 					<Form onSubmit={this.handleAdd}>
 						<Modal.Header>
 							<Modal.Title>Select your staff member</Modal.Title>
@@ -120,11 +120,11 @@ class StaffAdd extends React.Component {
 							</Form.Group>
 						</Modal.Body>
 						<Modal.Footer>
-							<Button variant="outline-secondary" onClick={this.handleClose}>
+							<Button variant="outline-secondary" data-testid="cancelStaffAdd-id" onClick={this.handleClose}>
 								Close
 							</Button>
-							<Button variant="outline-primary" type="submit">
-								Add new Staff
+							<Button variant="outline-primary" data-testid = "addStaffConfirm-id" type="submit">
+								Add New Staff
 							</Button>
 						</Modal.Footer>
 					</Form>

--- a/src/components/main/StaffBudget.js
+++ b/src/components/main/StaffBudget.js
@@ -1,0 +1,43 @@
+import React from 'react';
+
+class StaffBudget extends React.Component {
+
+    // grab staff info and add up budget
+    getShiftBudget = (staffs) => {
+        let shiftBudget = 0;
+
+        for (var i = 0; i < staffs.length; i++) {
+            let shiftTotal = parseInt(staffs[i].shiftTotal);
+            if (staffs[i].type === 'RN') {
+                shiftBudget += shiftTotal * 35;
+            } else if (staffs[i].type === 'LVN') {
+                shiftBudget += shiftTotal * 24;
+            } else {
+                shiftBudget += shiftTotal * 15;
+            }
+        }
+
+        return shiftBudget;
+    }
+
+    render() {
+
+        const shiftBudget = this.getShiftBudget(this.props.staffs);
+        return (
+    //         const content = this.state.checked 
+    //   ? <div> Content </div>
+    //   : null;
+            this.props.showBudget ?
+            <div className="card mt-4">
+                <div className="card-header">Total Budget for Staff</div>
+                <div id="budget" className="card-body">
+                    <h1 data-testid="shiftBudgetValue-id">${shiftBudget}</h1>
+                </div>
+            </div>
+            :
+            null
+        )
+    }
+}
+
+export default StaffBudget;

--- a/src/components/main/StaffList.js
+++ b/src/components/main/StaffList.js
@@ -58,13 +58,13 @@ class StaffList extends React.Component {
         const staffList = this.props.staffs.map((staff, i) =>
             <tr key={staff.id} id={staff.id} >
                 <td >
-                    <Trash className="bTrash" onClick={this.listRemove.bind(staff,i)} />
+                    <Trash className="bTrash" data-testid="delete-id" onClick={this.listRemove.bind(staff,i)} />
                 </td>
                 <td >{staff.type}</td>
                 <td>
-                   <Plus className="bPlus" onClick={this.listAdd.bind(staff,i)}/> 
+                   <Plus className="bPlus" data-testid="add-id" onClick={this.listAdd.bind(staff,i)}/> 
                    {staff.quantity} 
-                   <Dash className="bDash" onClick={this.listSub.bind(staff,i)}/>
+                   <Dash className="bDash" data-testid="minus-id" onClick={this.listSub.bind(staff,i)}/>
                 </td>
                 <td>{staff.shift}</td>
                 <td>{staff.shiftTotal}</td>
@@ -76,7 +76,7 @@ class StaffList extends React.Component {
            
                     <table className="table table-striped table-hover" id="staffCont">
                         <thead className="table-BSU">
-                            {staffList.length > 0 ? <tr>
+                            {staffList.length > 0 ? <tr data-testid="staffList-id">
                                 <th></th>
                                 <th scope="col">Staff Type</th>
                                 <th scope="col">Quantity</th>


### PR DESCRIPTION
Closes #78 

I reworked how the layout was set up in Scenario.js because when I added in the budget, it was pushing down the stafflist. It's not doing that anymore, so the budget pops up to the right of the stafflist, under the total HPPD remaining box. I also added in tests for the staff budget. And I pulled down the changes from my button test branch since I have a PR out for that. That way there shouldn't be any merge conflicts if the button test PR is merged into main first.