### PR TITLE
parseint

### DIFF
--- a/src/components/main/Scenario.js
+++ b/src/components/main/Scenario.js
@@ -102,7 +102,7 @@ class Scenario extends React.Component {
   // https://dev.to/alecgrey/controlled-forms-with-front-and-backend-validations-using-react-bootstrap-5a2
   findFormErrors = (name, val) => {
     const newErrors = {};
-
+    val = parseInt(val);
     if (name === "HPPD") {
       // HPPD errors
       if (!val || val === "") newErrors.HPPD = "HPPD cannot be blank!";


### PR DESCRIPTION
fixed the bug. the state.info fields are strings so have to parseint the values when doing the error checks in order for the comparison between numbers to work